### PR TITLE
Library Updates and OCR Fixes with Automato changes

### DIFF
--- a/scripts/common.inc
+++ b/scripts/common.inc
@@ -50,7 +50,8 @@ end
 -------------------------------------------------------------------------------
 
 function makePoint(x, y)
-  if not x or not y then
+  if x == nil or y == nil then
+    print(debug.traceback());
     error("Incorrect number of arguments for makePoint()");
   end
   local result = {};

--- a/scripts/common_click.inc
+++ b/scripts/common_click.inc
@@ -264,18 +264,24 @@ function drawWater()
 end
 
 ------------------------------------------------------------------------------
--- clickText(parse)
+-- clickText(parse, safe)
 --
 -- convenient wrapper to click on text 20, 7 pixels in from where the top
 -- left of the parse object
 -- parse - parse object which we're clicking
---
+-- safe - Set to false if you want to do an unsafe click
 -- always returns nil
 ------------------------------------------------------------------------------
 
-function clickText(parse)
-	srClickMouseNoMove(parse[0] + 20, parse[1] + 7);
-	lsSleep(per_click_delay);
+function clickText(parse, safe)
+  if parse then
+    if safe and safe ~= false then
+      safeClick(parse[0] + 20, parse[1] + 7, 0);
+    else
+      srClickMouseNoMove(parse[0] + 20, parse[1] + 7);
+      lsSleep(per_click_delay);
+    end
+  end
 end
 
 -------------------------------------------------------------------------------

--- a/scripts/common_fix.inc
+++ b/scripts/common_fix.inc
@@ -111,5 +111,5 @@ end
 -------------------------------------------------------------------------------
 
 function findInventoryRegion()
-  return regionToBox(srFindInventoryRegion());
+  return regionToBox(srFindInvRegion());
 end

--- a/scripts/common_gps.inc
+++ b/scripts/common_gps.inc
@@ -1,45 +1,22 @@
+-----------------------------------------------------------
+-- findCoords()
+--
+-- returns a Point object containing the current x and y
+-- coordinates. Use this over fastFindCoords, which is
+-- misnamed and is oddly significantly slower.
+----------------------------------------------------------
 function findCoords()
-  lsPrintln("findCoords");
   local result = nil;
   local anchor = findText("Year");
-  if(not anchor) then
-    anchor = findText("ar 1");
-  end
-  if(not anchor) then
-    anchor = findText("ar 2");
-  end
-  if(not anchor) then
-    anchor = findText("ar 3");
-  end
-  if(not anchor) then
-    anchor = findText("ar 4");
-  end
-  if(not anchor) then
-    anchor = findText("ar 5");
-  end
-  if(not anchor) then
-    anchor = findText("ar 6");
-  end
-  if(not anchor) then
-    anchor = findText("ar 7");
-  end
-  if(not anchor) then
-    anchor = findText("ar 8");
-  end
-  if(not anchor) then
-    anchor = findText("ar 9");
-  end
-
 
   if anchor then
-    lsPrintln("anchor");
     local window = getWindowBorders(anchor[0], anchor[1]);
     local lines = findAllText(nil, window, NOPIN);
-    for i=1,#lines do
-      lsPrintln("LINE " .. i .. " : " .. table.concat(lines[i], ","));
-    end
+--    for i=1,#lines do
+--      lsPrintln("LINE " .. i .. " : " .. table.concat(lines[i], ","));
+--    end
     local str = lines[#lines][2];
-    lsPrintln("lines: " .. str);
+--    lsPrintln("lines: " .. str);
     local a, b, x, y = string.find(str, ": ([0-9-]+)\, ([0-9-]+)");
     result = makePoint(tonumber(x), tonumber(y));
     if not result[0] or not result[1] then
@@ -124,6 +101,12 @@ local ffc_coordsPos = nil;
 local ffc_dash = -1;
 local ffc_comma = -2;
 
+------------------------------------------------------------------------------------
+-- fastFindCoords()
+--
+-- DEPRECATED. Less reliable and nearly 10x slower than findCoords().
+-- Use findCoords() instead. Returns the current coordinates as a Point object.
+------------------------------------------------------------------------------------
 function fastFindCoords()
 	local pos;
 	if(not ffc_coordsPos) then
@@ -131,17 +114,21 @@ function fastFindCoords()
 		if(not pos) then
 			pos = findText("Year");
 			if(not pos) then
-				pos = findText("2, ");
-				if(not pos) then
-					pos = findText("3, ");
-					if(not pos) then
-						lsPrintln("fastFindCoords() : Can't find the clock");
-						return nil;
+				for i=1,9 do
+					pos = findText("ar " .. i .. ", ");
+					if(pos) then
+						break
 					end
+				end
+				
+				if(not pos) then
+					lsPrintln("fastFindCoords() : Can't find the clock");
+					return nil;
 				end
 			end
 		end
 		local window = getWindowBorders(pos[0], pos[1]);
+    srReadScreen(); -- required due to image search functions after a potential text search.
 		window.top = window.top + 13;
 		window.y = window.y + 13;
 		window.height = window.height - 13;
@@ -172,6 +159,11 @@ function fastFindCoords()
 	return nil;
 end
 
+-----------------------------------------------------------------------------
+-- ffc_parseDigits(digits)
+--
+-- Helper function for fastFindCoords(). Deprecated.
+-----------------------------------------------------------------------------
 function ffc_parseDigits(digits)
 	local x;
 	local pos;
@@ -190,6 +182,11 @@ function ffc_parseDigits(digits)
 	return makePoint(x,y);
 end
 
+-------------------------------------------------------------------------------
+-- ffc_parseOneCoord(digits, pos)
+--
+-- Helper function for fastFindCoords(). Deprecated.
+------------------------------------------------------------------------------
 function ffc_parseOneCoord(digits,pos)
 	if(pos == nil) then
 		pos = 1;
@@ -220,6 +217,11 @@ function ffc_parseOneCoord(digits,pos)
 	return val, #digits+1;
 end
 
+-----------------------------------------------------------------------------
+-- ffc_readDigits(box)
+--
+-- Helper function for fastFindCoords(). DEPRECATED.
+-----------------------------------------------------------------------------
 function ffc_readDigits(box)
 	local digits = {};
 	local i;
@@ -255,6 +257,11 @@ function ffc_readDigits(box)
 	return digits;
 end
 
+-----------------------------------------------------------------------------
+-- ffc_compareDigits(left,right)
+--
+-- Helper function for fastFindCoords(). DEPRECATED.
+-----------------------------------------------------------------------------
 function ffc_compareDigits(left,right)
 	if(left[1] < right[1]) then
 		return true;

--- a/scripts/common_text.inc
+++ b/scripts/common_text.inc
@@ -5,8 +5,10 @@
 -- Intentionally does not find regions where a corner is covered up.
 --
 -- Returns an array of region objects on success, nil if no regions are found.
+-- DEPRECATED. Use findText or findAllText instead.
 -------------------------------------------------------------------------------
 function findAllTextRegions()
+  lsPrintln("findAllTextRegions is deprecated. Do not call this anymore");
 	local xyWindowSize = srGetWindowSize();
 	local y = 0;
 	local buttons = {};
@@ -24,7 +26,7 @@ function findAllTextRegions()
 	end
 	local i;
 	for i = 1, #buttons do
-		buttons[i][0] = buttons[i][0] + 4;
+		buttons[i][0] = buttons[i][0] + 1;
 		buttons[i][1] = buttons[i][1] + 1;
 		buttons[i][2] = buttons[i][2] - 30;
 		buttons[i][3] = buttons[i][3] - 2;
@@ -33,7 +35,7 @@ function findAllTextRegions()
 end
 
 -------------------------------------------------------------------------------
--- findText(text, isExact)
+-- findTextOld(text, isExact)
 --
 -- Searches for the specified text in normal papyrus regions.  Intentionally
 -- does not check the inventory region and chat regions.  if isExact is true,
@@ -45,9 +47,11 @@ end
 -- Returns a parse object containing the entire line of text that the text
 -- object was found within. findText("Wood (") for instance will return
 -- "Wood (154)" if done on a chest with 154 wood.
+-- DEPRECATED. use findText() instead.
 -------------------------------------------------------------------------------
 
 function findTextOld(text, isExact)
+  lsPrintln("findtextOld IS DEPRECATED. use findText() instead");
 	if text == nil then
 		error "No text specified to find";
 	end
@@ -102,7 +106,7 @@ end
 
 function parseRegion(region)
 	if region then
-		return parseText(region[0], region[1], region[2], region[3]);
+    return parseText(region[0], region[1], region[2], region[3]);
 	end
 end
 
@@ -117,8 +121,10 @@ end
 -- the exact text specified
 --
 -- returns the parse object containing the desired text.
+-- DEPRECATED. use findText() instead.
 -------------------------------------------------------------------------------
 function findTextInRegion(region, text, isExact)
+  lsPrintln("findTextInRegion IS DEPRECATED. use findText instead");
 	if region then
 		stripRegion(region);
 		local table = parseRegion(region);
@@ -182,8 +188,10 @@ end
 -- the exact text specified
 --
 -- returns an array of region objects, all of which contained the desired text.
+-- DEPRECATED. use findAllText() instead.
 -------------------------------------------------------------------------------
 function findAllRegionsWithText(text, isExact)
+  lsPrintln("findAllRegionsWithText IS DEPRECATED! Use findAllText() instead");
 	local r1 = findAllTextRegions();
 	local count = 0;
 	local r2 = {}
@@ -214,20 +222,10 @@ end
 
 function getChatText()
 	local creg = srFindChatRegion();
+  -- The below line is a hack introduced for T7 to handle the fact that
+  -- there isn't as much of a buffer below chat as there was in T6 and prior.
+  creg[3] = creg[3] + 1;
 	stripRegion(creg);
-	local lreg = {};
-	if creg then
-		local w = creg[2];
-		if creg[2] > 600 then
-			creg[0] = creg[0] + 106;
-			creg[2] = creg[2] - 106;
-		else
-			creg[0] = creg[0] + w/6 + 6;
-			creg[2] = creg[2] - w/6 - 6;
-		end
-	else
-		return nil;
-	end
 	local p = parseRegion(creg);
 	local count = 1;
 	local first = nil;
@@ -260,9 +258,10 @@ end
 -------------------------------------------------------------------------------
 -- getAllText()
 --
--- finds all the text on the screen.  May need depreciation.
+-- finds all the text on the screen.  May need deprecation.
 --
 -- returns an array of parse objects of every item on the screen.
+-- Generally only useful for debug
 -------------------------------------------------------------------------------
 
 function getAllText()
@@ -300,9 +299,11 @@ end
 -- the exact text specified
 --
 -- returns the first region object containing the desired text
+-- DEPRECATED. use findText() instead.
 -------------------------------------------------------------------------------
 
 function findRegionWithText(text, isExact)
+  lsPrintln("findRegionWithText IS DEPRECATED! use findText() instead");
 	f = findAllTextRegions();
 	local i;
 	if f then

--- a/scripts/common_window.inc
+++ b/scripts/common_window.inc
@@ -190,7 +190,7 @@ end
 -- waterGap (optional) -- leave a gap at the top for getting water
 -------------------------------------------------------------------------------
 
-function arrangeStashed(cascade, waterGap)
+function arrangeStashed(cascade, waterGap, varWidth, varHeight)
   local screen = srGetWindowSize();
   local bottomRightX = screen[0] - 20;
   local bottomRightY = screen[1] - 20;
@@ -212,25 +212,35 @@ function arrangeStashed(cascade, waterGap)
     lsSleep(click_delay);
     srReadScreen();
     local bounds = srGetWindowBorders(window[0], window[1]);
-    local width = bounds[2] - bounds[0];
-    local height = bounds[3] - bounds[1];
+    local width, height;
+    if not varWidth then
+      width = bounds[2] - bounds[0];
+    else
+      width = varWidth;
+    end
+    if not varHeight then
+      height = bounds[3] - bounds[1];
+    else
+      height = varHeight;
+    end
+    
     if cascade then
       if currentY + height >= screen[1] then
-	currentX = currentX + xMax;
-	currentY = 0;
-	xMax = 0;
+        currentX = currentX + xMax;
+        currentY = 0;
+        xMax = 0;
       end
       if currentX + width >= screen[0] then
-	error("Cannot arrange these windows into a cascade.");
+        error("Cannot arrange these windows into a cascade.");
       end
     else
       if currentX + width >= screen[0] then
-	currentX = 0;
-	currentY = currentY + yMax;
-	yMax = 0;
+        currentX = 0;
+        currentY = currentY + yMax;
+        yMax = 0;
       end
       if currentY + height >= screen[1] then
-	error("Cannot arrange these windows into a grid.");
+        error("Cannot arrange these windows into a grid.");
       end
     end
     lastX = window[0] - bounds[0] + currentX;
@@ -291,6 +301,25 @@ function closeAllWindows(x, y, width, height)
 	sleepWithStatus(200, "Closing Windows");
 	srReadScreen();
 	images = findAllImagesInRange(image, x, y, width, height);
+      end
+    end
+  end
+end
+
+-------------------------------------------------------------------------------
+-- closeEmptyRegions()
+--
+-- Closes all empty windows on the screen
+--
+-------------------------------------------------------------------------------
+
+function closeEmptyRegions()
+  allRegs = findAllTextRegions();
+  if allRegs then
+    for i = 1, #allRegs do
+      local p = parseRegion(allRegs[i]);
+      if p == nil then
+        unpinRegion(allRegs[i]);
       end
     end
   end
@@ -441,6 +470,21 @@ function unpinManager(title, message)
     end
     lsDoFrame();
     lsSleep(tick_delay);
+  end
+end
+
+-------------------------------------------------------------------------------
+-- unpinRegion(region)
+--
+-- Unpins a region
+--
+-- region - region object to unpin
+-------------------------------------------------------------------------------
+
+function unpinRegion(region)
+  if region then
+    lsPrintln("Unpinning at: " .. region[0] + region[2] - 15 .. ", " .. region[1] + region[3] + 15);
+    safeClick(region[0] + region[2] - 15, region[1] + 15, 0);
   end
 end
 


### PR DESCRIPTION
Contains some fixes that go along with the latest commit to the SVN repo - mostly text related, but also one change related to removing the readScreen from getWindowBorders.

This commit does have some breaking changes if not accompanied with the update to automato.exe, namely some of the ones that adjust offsets and the removal of extra code from findCoords.

I did go through and mark some functions as deprecated, all of them either text functions that are better served by findText or findAllText, or fastFindCoords, which is significantly slower than findCoords.
