### PR TITLE
Revert "Improved drawWater stability"

### DIFF
--- a/scripts/common_click.inc
+++ b/scripts/common_click.inc
@@ -252,7 +252,6 @@ function drawWater()
     local water = srFindImage("iconWaterJugSmall.png", 1);
     if water then
       safeClick(water[0]+3, water[1]-5);
-      lsSleep(click_delay*5);
       local max = waitForImage("crem-max.png", 500, "Waiting for Max button");
       if max then
         safeClick(max[0]+5, max[1]+5);


### PR DESCRIPTION
This reverts commit b7cd4a4776aefb1497df78a8acc654a7a74a37ad. This commit
was discovered to provide a workaround for a bug that only affected users
with 'Max' in their usernames and only while standing over certain
terrain. Alternative and more permanent solution being investigated
