### PR TITLE
Fix bug when watergap is true.

### DIFF
--- a/scripts/common_window.inc
+++ b/scripts/common_window.inc
@@ -198,7 +198,6 @@ function arrangeStashed(cascade, waterGap, varWidth, varHeight)
   local currentX = 0;
   local currentY = 0;
   if waterGap then
-    currentX = 10;
     currentY = 50;
   end
   local lastX = 0;


### PR DESCRIPTION
When the water_gap flag was set, the top row of pinned menus would be put
in place and then missed due to the X offset, requiring them to be readded
to the bottom line of the pinning
