### PR TITLE
Add sizemod parameter to text functions

### DIFF
--- a/scripts/common_find.inc
+++ b/scripts/common_find.inc
@@ -146,6 +146,10 @@ BROWSE_INVENTORY = {3, 40, -379, -11};
 BROWSE_CHEST = {354, 40, -379, -11};
 
 function findAllText(text, window, flag, sizemod)
+  if flag == NOPIN then
+    sizemod = NOPIN
+    flag = nil;
+  end
   if sizemod == nil then
     sizemod = PINNED;
   end

--- a/scripts/common_find.inc
+++ b/scripts/common_find.inc
@@ -120,27 +120,39 @@ end
 -- suffice. If unset, any line containing the text will be returned.
 EXACT = 1;
 -- If set, this window does not contain a pin in the corner.
-NOPIN = 2;
 -- If set, returns the window containing the text rather than the parse.
 REGION = 4;
-EXACT_NOPIN = 3;
+-- If set ignores all but the first instance in each window.
 EXACT_REGION = 5;
-NOPIN_REGION = 6;
-EXACT_NOPIN_REGION = 7;
 REGEX = 8;
 
-function findText(text, window, flag)
-  local parses = findAllText(text, window, flag);
-  local result = nil;
-  if #parses >= 1 then
-    result = parses[1];
-  end
-  return result;
+function findText(text, window, flag, sizemod)
+   local parses = findAllText(texts, windows, flag, sizemod);
+   local result = nil;
+   if #parses >= 1 then
+      result = parses[1];
+   end
+   return result;
 end
 
-function findAllText(text, window, flag)
+-- Set of window sizes for sizemod field. Values listed are added to x, y,
+-- width, height of each window, respectively
+NOPIN = {0, 0, 0, 0};
+PINNED = {0, 0, -20, 0};
+INFO_POPUP = {10, 10, -40, -62};
+CPLX_ITEM_CHOOSE = {9, 69, -40, -103};
+SLIGHT_INSET = {10, 0, -20, 0};
+BROWSE_INVENTORY = {3, 40, -379, -11};
+BROWSE_CHEST = {354, 40, -379, -11};
+
+function findAllText(text, window, flag, sizemod)
+  if sizemod == nil then
+    sizemod = PINNED;
+  end
+  if #sizemod ~= 4 then
+    error("Incorrect sizemod argument to text function");
+  end
   local exact = flag and (flag % 2 == 1);
-  local nopin = flag and (math.floor(flag/2) % 2 == 1);
   local region = flag and (math.floor(flag/4) % 2 == 1);
   local regex = flag and (math.floor(flag/8) % 2 == 1);
   
@@ -156,25 +168,20 @@ function findAllText(text, window, flag)
 
   for i=1,#windowList do
     local current = makeBox(windowList[i].x + 7, windowList[i].y + 4,
-          windowList[i].width - 12, windowList[i].height - 7);
-    if not nopin then
-      current = makeBox(current.x, current.y,
-      current.width - 20, current.height);
-    end
+          windowList[i].width - 12, windowList[i].height - 7); -- Basic magic # window resizing
+	       current = makeBox(current.x + sizemod[1], current.y + sizemod[2], current.width + sizemod[3], 
+                        current.height + sizemod[4]); -- Add in custom window resizing
     local parses = parseWindow(current);
     for j=1,#parses do
---      lsPrintln("parse: " .. parses[j][2]);
-      if not text
-  or (exact and parses[j][2] == text)
-  or (not exact and string.find(parses[j][2], text, 1, true))
-   or (regex and string.find(parses[j][2], text, 1))
-      then
-  if region then
-    table.insert(results, windowList[i]);
-    break;
-  else
-    table.insert(results, parses[j]);
-  end
+      if not text or (exact and parses[j][2] == text)
+                  or (not exact and string.find(parses[j][2], text, 1, true))
+                  or (regex and string.find(parses[j][2], text, 1)) then
+        if region then
+          table.insert(results, windowList[i]);
+          break;
+        else
+          table.insert(results, parses[j]);
+        end
       end
     end
   end

--- a/scripts/common_find.inc
+++ b/scripts/common_find.inc
@@ -127,7 +127,7 @@ EXACT_REGION = 5;
 REGEX = 8;
 
 function findText(text, window, flag, sizemod)
-   local parses = findAllText(texts, windows, flag, sizemod);
+   local parses = findAllText(text, window, flag, sizemod);
    local result = nil;
    if #parses >= 1 then
       result = parses[1];

--- a/scripts/common_gps.inc
+++ b/scripts/common_gps.inc
@@ -11,7 +11,7 @@ function findCoords()
 
   if anchor then
     local window = getWindowBorders(anchor[0], anchor[1]);
-    local lines = findAllText(nil, window, NOPIN);
+    local lines = findAllText(nil, window, nil, NOPIN);
 --    for i=1,#lines do
 --      lsPrintln("LINE " .. i .. " : " .. table.concat(lines[i], ","));
 --    end
@@ -72,7 +72,7 @@ local gpsStep;
 -- Returns nil if the date cannot be obtained
 ---------------------------------------------------------------
 function getTime(fmt)
-   local t = findAllText("Year", nil, NOPIN);
+   local t = findAllText("Year", nil, nil, NOPIN);
    if t == nil then
       return t;
    end

--- a/scripts/common_wait.inc
+++ b/scripts/common_wait.inc
@@ -186,8 +186,9 @@ function iterateText(args)
   local text = args[1];
   local range = args[2];
   local flags = args[3];
+  local sizemod = args[4];
   srReadScreen();
-  return findText(text, range, flags);
+  return findText(text, range, flags, sizemod);
 end
 
 ------------------------------------------------------------------------------

--- a/scripts/common_wait.inc
+++ b/scripts/common_wait.inc
@@ -250,7 +250,7 @@ function waitForImage(file, timeout, message, range, tol)
 end
 
 -------------------------------------------------------------------------------
--- waitForText(text, timeout, message, range, flags)
+-- waitForText(text, timeout, message, range, flags, sizemod)
 --
 -- Wait for a particular image to appear subject to a timeout in ms.
 --
@@ -259,19 +259,20 @@ end
 -- message (optional) -- Status message to show while waiting
 -- range (optional) -- box to restrict search
 -- flags (optional) -- same flags as findText()
+-- sizemod (optional) -- same constants as findText()
 --
 -- returns parse object on success or none on failure
 -------------------------------------------------------------------------------
 
-function waitForText(text, timeout, message, range, flags)
+function waitForText(text, timeout, message, range, flags, sizemod)
   if not text then
     error("Incorrect number of arguments for waitForText()");
   end
-  return waitForFunction(iterateText, {text, range, flags}, timeout, message);
+  return waitForFunction(iterateText, {text, range, flags, sizemod}, timeout, message);
 end
 
 -------------------------------------------------------------------------------
--- waitForNoText(text, timeout, message, range, flags)
+-- waitForNoText(text, timeout, message, range, flags, sizemod)
 --
 -- Wait for a particular text to disappear subject to a timeout in ms.
 --
@@ -280,15 +281,16 @@ end
 -- message (optional) -- Status message to show while waiting
 -- range (optional) -- box to restrict search
 -- flags (optional) -- same flags as findText()
+-- sizemod (optional) -- same constants as findText()
 --
 -- returns parse object on success or none on failure
 -------------------------------------------------------------------------------
 
-function waitForNoText(text, timeout, message, range, flags)
+function waitForNoText(text, timeout, message, range, flags, sizemod)
   if not text then
     error("Incorrect number of arguments for waitForText()");
   end
-  return waitForFunction(iterateText, {text, range, flags}, timeout, message, true);
+  return waitForFunction(iterateText, {text, range, flags, sizemod}, timeout, message, true);
 end
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
The sizemod parameter allows you to use a set list of variables to modify which part of a window you want to parse text from. Particularly useful when you need to do things like wait for an error/info popup, or wait for a complex item selection screen.

This does rename the NOPIN parameter for simplicity, and will break any scripts that currently use it. I've updated all scripts in this and the ATITD-Common repos that use this variable
