### PR TITLE
Update common_gps.inc

### DIFF
--- a/scripts/common_gps.inc
+++ b/scripts/common_gps.inc
@@ -16,8 +16,22 @@ function findCoords()
 --      lsPrintln("LINE " .. i .. " : " .. table.concat(lines[i], ","));
 --    end
     local str = lines[#lines][2];
---    lsPrintln("lines: " .. str);
+    --lsPrintln("lines: " .. str);
     local a, b, x, y = string.find(str, ": ([0-9-]+)\, ([0-9-]+)");
+	--  Fix for T8 as a 3rd line is now often present in the clock. Region Owned or Controlled by.
+--  Sometimes it's not there, such as when there's no owner/controller of a region.
+--  When it is there, this code reads the wrong line hunting for coords, so reading the previous line
+--  servers as a fix. Somewhat fragile as it'll need to be updated in the future if more lines
+--  are added to the clock. -Tizuby
+    if x == nil then
+	str = lines[#lines - 1][2];
+	a, b, x, y = string.find(str, ": ([0-9-]+)\, ([0-9-]+)");
+    end
+--  One more check to ensure x and y have values. If they're nil, exit with a friendlier message than.
+--  "wrong number of parameters sent to makePoint". -Tizuby
+    if x == nil or y == nil then
+	error("Could not find coordinates from the clock.");
+    end
     result = makePoint(tonumber(x), tonumber(y));
     if not result[0] or not result[1] then
       result = nil;


### PR DESCRIPTION
Added an additional if check for the new T8 faction region system which adds a line to the clock to say which faction controls the region. Breaks findCoords() when that third line is present.

Added a check so that if coordinates are not found in the normal place (last line of the clock) it'll check the previous line to see if coords are there. The new line doesn't show up if no faction controls a region, so both cases need to be handled.